### PR TITLE
properly configure cpphs

### DIFF
--- a/bed-and-breakfast.cabal
+++ b/bed-and-breakfast.cabal
@@ -32,7 +32,7 @@ Library
                         template-haskell >= 2.7,
                         cpphs >= 1.18
     Hs-Source-Dirs:     src
-    GHC-Options:        -Wall -pgmPcpphs -optP--cpp
+    GHC-Options:        -Wall -cpp -pgmP "cpphs --cpp"
     Extensions:         CPP
 
 Test-Suite quickcheck


### PR DESCRIPTION
bed-and-breakfast is failing to be built by nixpkgs. [See this build log](https://hydra.nixos.org/build/233221152/nixlog/2), but the relevant bit is:

```
cc1: error: unrecognized command-line option ‘--cpp’

<no location info>: error:
    `cc' failed in phase `C Compiler'. (Exit code: 1)
```

googling around, I found [this comment](https://gitlab.haskell.org/ghc/ghc/-/issues/16737#note_225454), which describes a _different_ set of parameters to pass to GHC than the ones that cpphs recommends (which is weird, right?)

anyways, I've verified that with this patch, bed-and-breakfast is successfully built by nixpkgs