### PR TITLE
Correct off-by-one error in default implementation of `at`

### DIFF
--- a/src/Numeric/Matrix.hs
+++ b/src/Numeric/Matrix.hs
@@ -497,7 +497,7 @@ class (Eq e, Num e) => MatrixElement e where
                               , j <- [1..numCols m]
                               , p (i,j) ]
 
-    at mat (i, j) = ((!! j) . (!! i) . toList) mat
+    at mat (i, j) = ((!! (j-1)) . (!! (i-1)) . toList) mat
     
     row i = (!! (i-1)) . toList
     col i = row i . transpose


### PR DESCRIPTION
According to the documentation, `at` uses "indices start at one, not at zero".